### PR TITLE
Allow host to be specified by "name"

### DIFF
--- a/amicli.c
+++ b/amicli.c
@@ -148,7 +148,7 @@ int main(int argc,char *argv[])
 	int debug = 0;
 	struct ami_session *ami;
 
-	while ((c = getopt(argc, argv, getopt_settings)) != -1) {
+	while ((c = getopt(argc, argv, getopt_settings)) != (char) -1) {
 		switch (c) {
 		case '?':
 		case 'd':

--- a/include/cami.h
+++ b/include/cami.h
@@ -50,7 +50,7 @@ struct ami_response {
 
 /*!
  * \brief Enable debug logging
- * \param ami
+ * \param ami The AMI session. If NULL, sets the file descriptor for debug logging prior to session creation (e.g. in ami_connect)
  * \param fd File descriptor to which optional debug log messages should be delivered. Default is off (-1)
  * \note This is not recommended for use in production, but may be helpful in a dev environment.
  */
@@ -59,6 +59,7 @@ void ami_set_debug(struct ami_session *ami, int fd);
 /*!
  * \brief Set debug logging level
  * \param ami
+ * \param ami The AMI session. If NULL, sets the debug level prior to session creation (e.g. in ami_connect)
  * \param level Level between 0 and 10. 0 will disable logging, 10 is the most granular. Default is 0.
  * \note A log level of 1 is recommended for production use: this will log all errors and warnings. Use a greater log level for debugging.
  * \retval -1 on failure, non-negative old log level otherwise

--- a/simpleami.c
+++ b/simpleami.c
@@ -36,6 +36,8 @@
 static void simple_callback(struct ami_session *ami, struct ami_event *event)
 {
 	const char *eventname = ami_keyvalue(event, "Event");
+	(void) ami;
+
 	printf("(Callback) Event Received: %s\n", eventname);
 #if 0
 	/* Or, you could print out the entire event contents for debugging, or to see what's there: */
@@ -57,8 +59,8 @@ static int simple_ami(const char *hostname, const char *username, const char *pa
 	struct ami_session *ami;
 	struct ami_response *resp = NULL;
 #if 0
-	ami_set_debug(STDERR_FILENO); /* Not recommended for daemon programs */
-	ami_set_debug_level(1);
+	ami_set_debug(NULL, STDERR_FILENO); /* Not recommended for daemon programs */
+	ami_set_debug_level(NULL, 1);
 #endif
 	ami = ami_connect(hostname, 0, simple_callback, simple_disconnect_callback);
 	if (!ami) {
@@ -95,6 +97,9 @@ static int simple_ami(const char *hostname, const char *username, const char *pa
 
 int main(int argc,char *argv[])
 {
+	(void) argc;
+	(void) argv;
+
 	if (simple_ami("127.0.0.1", "test", "test")) {
 		exit(EXIT_FAILURE);
 	}


### PR DESCRIPTION
- updated ami_connect() to allow the host to be specified by DNS "name" (and not just IP address)

- the ami_set_debug_level() function currently requires a session to be specified.  This means that there is no way to control the debug level (and any assciated outut) before a session is established.  Updated the code to allow one to pass a NULL session to set the default (and pre-session) debug level.

- Allow compilation on macOS