### PR TITLE
CI: Add additional CI for non-Debian systems.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,16 +12,7 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  vm:
-    # The type of runner that the job will run on
-    runs-on: ubuntu-latest
-
-    # Steps represent a sequence of tasks that will be executed as part of the job
-    steps:
-      # Runs a set of commands using the runners shell
-      - name: Start build
-        run: echo Beginning build
-  container:
+  debian-12:
     runs-on: ubuntu-latest
     container: debian:12
     steps:
@@ -53,3 +44,16 @@ jobs:
           make install
           make examples
           ./simpleami
+  fedora-42:
+    runs-on: ubuntu-24.04
+    name: Fedora 42
+    container: fedora:42
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Build CAMI and execute simple demo
+        run: |
+          dnf install -y make gcc
+          make
+          make install
+          make examples

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 #
 
 CC		= gcc
-CFLAGS = -Wall -Werror -Wno-unused-parameter -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wformat=2 -Wshadow -std=gnu99 -pthread -O0 -g -Wstack-protector -fno-omit-frame-pointer -D_FORTIFY_SOURCE=2 -I.
+CFLAGS = -Wall -Werror -Wno-unused-parameter -Wextra -Wstrict-prototypes -Wmissing-prototypes -Wdeclaration-after-statement -Wmissing-declarations -Wmissing-format-attribute -Wformat=2 -Wshadow -std=gnu99 -pthread -O3 -g -Wstack-protector -fno-omit-frame-pointer -D_FORTIFY_SOURCE=2 -I.
 EXE		= cami
 SAMPEXES = simpleami amicli
 LIBNAME	= lib$(EXE).so


### PR DESCRIPTION
Some gcc errors only occur on non-Debian systems,
so add a non-Debian build for comprehensiveness.